### PR TITLE
fixes #188

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,12 +1,15 @@
-Paperclip::Attachment.default_options.update({
+if Rails.env.development? || Rails.env.test?
+  Paperclip::Attachment.default_options[:storage] = 'filesystem'
+else
+  Paperclip::Attachment.default_options.update({
     storage: :s3,
     s3_protocol: 'https',
 
     s3_credentials: {
-        s3_region: ENV.fetch('AWS_REGION', 'us-east-1'),
-        bucket: ENV.fetch('BUCKETEER_BUCKET_NAME') { ENV.fetch('AWS_BUCKET') },
-        access_key_id: ENV.fetch('BUCKETEER_AWS_ACCESS_KEY_ID') { ENV.fetch('AWS_ACCESS_KEY_ID') },
-        secret_access_key: ENV.fetch('BUCKETEER_AWS_SECRET_ACCESS_KEY') { ENV.fetch('AWS_SECRET_ACCESS_KEY') }
+      s3_region: ENV.fetch('AWS_REGION', 'us-east-1'),
+      bucket: ENV.fetch('BUCKETEER_BUCKET_NAME') { ENV.fetch('AWS_BUCKET') },
+      access_key_id: ENV.fetch('BUCKETEER_AWS_ACCESS_KEY_ID') { ENV.fetch('AWS_ACCESS_KEY_ID') },
+      secret_access_key: ENV.fetch('BUCKETEER_AWS_SECRET_ACCESS_KEY') { ENV.fetch('AWS_SECRET_ACCESS_KEY') }
     },
 
     hash_secret: ENV.fetch('PAPERCLIP_HASH_SECRET'),
@@ -15,4 +18,5 @@ Paperclip::Attachment.default_options.update({
     s3_permissions: 'public-read'
     # s3_permissions: :private will allow download only via presigned URLs
     # https://github.com/thoughtbot/paperclip/wiki/Restricting-Access-to-Objects-Stored-on-Amazon-S3
-})
+  })
+end

--- a/spec/features/visitor/media/visitor_get_media_spec.rb
+++ b/spec/features/visitor/media/visitor_get_media_spec.rb
@@ -16,6 +16,6 @@ RSpec.feature feature, issues: ['railgun#84'] do
 
     visit media_path(media.slug)
 
-    expect(URI.parse(current_url).path).to eq(media.file.url)
+    expect(current_path).to eq(media.file.url)
   end
 end

--- a/spec/features/visitor/media/visitor_get_media_spec.rb
+++ b/spec/features/visitor/media/visitor_get_media_spec.rb
@@ -14,9 +14,8 @@ RSpec.feature feature, issues: ['railgun#84'] do
   scenario scenario do
     media = create(:media, slug: 'image')
 
-    expect{ visit media_path(media.slug) }.to raise_error(ActionController::RoutingError)
+    visit media_path(media.slug)
 
-    expect(page.status_code).to eq(303)
-    expect(page.current_url).to eq(media.file.url)
+    expect(URI.parse(current_url).path).to eq(media.file.url)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,11 +74,13 @@ RSpec.describe User do
     end
   end
 
-  it 'incorrect format', issues: ['railgun#175'] do
-    expect(build(:user, email: 'not_format_email_string')).not_to be_valid
-  end
+  context 'Email validation' do
+    it 'incorrect format', issues: ['railgun#175'] do
+      expect(build(:user, email: 'not_format_email_string')).not_to be_valid
+    end
 
-  it 'correct format', issues: ['railgun#190'] do
-    expect(build(:user, email: 'this correct format@email_string')).to be_valid
+    it 'correct format', issues: ['railgun#190'] do
+      expect(build(:user, email: 'this correct format@email_string')).to be_valid
+    end
   end
 end


### PR DESCRIPTION
In the spec, the status 303 is no longer checked because:
Production mode has status 200 for media.file.url and the spec test has status 200 too for now, apparently because the page is checked after the controller's redirect